### PR TITLE
Moves launching of RV to hook.

### DIFF
--- a/app.py
+++ b/app.py
@@ -12,34 +12,34 @@ import os
 from tank.platform import Application
 
 class NukeLaunchScreeningRoom(Application):
-    
+
     def init_app(self):
-        self.engine.register_command("Jump to Screening Room", 
+        self.engine.register_command("Jump to Screening Room",
                                      self._start_screeningroom,
                                      {"type": "context_menu", "short_name": "screening_room"})
-        
+
     def _get_rv_binary(self):
         """
         Returns the RV binary to run
         """
-        # get the setting        
+        # get the setting
         system = sys.platform
         try:
             app_setting = {"linux2": "rv_path_linux", "darwin": "rv_path_mac", "win32": "rv_path_windows"}[system]
             app_path = self.get_setting(app_setting)
             if not app_path: raise KeyError()
         except KeyError:
-            raise Exception("Platform '%s' is not supported." % system) 
-        
+            raise Exception("Platform '%s' is not supported." % system)
+
         if system == "darwin":
             # append Contents/MacOS/RV64 to the app bundle path
-            app_path = os.path.join(app_path, "Contents/MacOS/RV64") 
-        
+            app_path = os.path.join(app_path, "Contents/MacOS/RV64")
+
         return app_path
-        
+
     def _start_screeningroom(self):
         tk_multi_screeningroom = self.import_module("tk_multi_screeningroom")
-        
+
         # figure out the context for Screening Room
         # first try to get a version
         # if that fails try to get the current entity
@@ -51,9 +51,9 @@ class NukeLaunchScreeningRoom(Application):
             filters = [["sg_task", "is", task]]
             order   = [{"field_name": "created_at", "direction": "desc"}]
             fields  = ["id"]
-            version = self.shotgun.find_one("Version", 
-                                            filters=filters, 
-                                            fields=fields, 
+            version = self.shotgun.find_one("Version",
+                                            filters=filters,
+                                            fields=fields,
                                             order=order)
             if version:
                 # got a version
@@ -67,26 +67,27 @@ class NukeLaunchScreeningRoom(Application):
             filters = [["entity", "is", self.context.entity]]
             order   = [{"field_name": "created_at", "direction": "desc"}]
             fields  = ["id"]
-            version = self.shotgun.find_one("Version", 
-                                            filters=filters, 
-                                            fields=fields, 
+            version = self.shotgun.find_one("Version",
+                                            filters=filters,
+                                            fields=fields,
                                             order=order)
-            
+
             if version:
                 # got a version
                 rv_context = version
             else:
                 # no versions, fall back onto just the entity
                 rv_context = self.context.entity
-            
-        
+
+
         self.log_debug("Launching Screening Room for context %s" % rv_context)
-        
+
         try:
             tk_multi_screeningroom.screeningroom.launch_timeline(base_url=self.shotgun.base_url,
-                                                    context=rv_context,
-                                                    path_to_rv=self._get_rv_binary())
+                                                                 context=rv_context,
+                                                                 path_to_rv=self._get_rv_binary(),
+                                                                 tank_app=self)
         except Exception, e:
             self.log_error("Could not launch Screening Room - check your configuration! "
                                   "Error reported: %s" % e)
-    
+

--- a/hooks/screeningroom_launch_rv.py
+++ b/hooks/screeningroom_launch_rv.py
@@ -1,0 +1,28 @@
+#
+# Copyright (c) 2012 Shotgun Software, Inc
+# ----------------------------------------------------
+#
+"""
+Screeningroom Launch Rv.
+
+This hook is executed to launch rv.
+"""
+
+import os
+import sys
+import tank
+
+class ScreeningroomLaunchRv(tank.Hook):
+    """
+    Hook to launch rv.
+    """
+    def execute(self, rv_path, rv_args, **kwargs):
+        """
+        The execute functon of the hook will be called to start rv using the
+        arguments rv_args.
+
+        :param rv_path: (str) The path to rv
+        :param rv_args: (str) Any arguments rv may require
+        """
+        print("Running %s" % ' '.join([rv_path] + rv_args));
+        subprocess.Popen([rv_path] + rv_args)

--- a/info.yml
+++ b/info.yml
@@ -7,26 +7,32 @@
 
 # expected fields in the configuration file for this app
 configuration:
-    rv_path_windows:       
+    rv_path_windows:
         type: str
         default_value: "C:\\Program Files\\RV\\RV64.exe"
-        description: The path to the Rv executable on Windows.  
-    rv_path_linux:       
+        description: The path to the Rv executable on Windows.
+    rv_path_linux:
         type: str
-        default_value: "rv"  
-        description: The path to the Rv executable on Linux.  
-    rv_path_mac:       
+        default_value: "rv"
+        description: The path to the Rv executable on Linux.
+    rv_path_mac:
         type: str
-        default_value: "/Applications/RV64.app"  
-        description: The path to the Rv executable on Macosx.                  
+        default_value: "/Applications/RV64.app"
+        description: The path to the Rv executable on Macosx.
+    hook_launch_rv:
+        type: hook
+        default_value: screeningroom_launch_rv
+        description: "This hook is called when the actual call to launch rv
+                      occurs.  The configured path and rv arguements are
+                      provided as arguements"
 
 # this multi app runs in all engines
-supported_engines: 
+supported_engines:
 
 # the Shotgun fields that this app needs in order to operate correctly
 requires_shotgun_fields:
 
-# More verbose description of this item 
+# More verbose description of this item
 display_name: "Screening Room Integration"
 description: "Screening Room integration right inside your application."
 


### PR DESCRIPTION
By moving this to a hook we are able to use our custom app launching api.  Would the actual launching of RV occur with tk-multi-launchapp down the road?  Could simplify things once launchapp is able to launch apps that may not have an engine.  We already use the app_launch hook in launchapp to use our custom launching api.

thanks!

-tony
