### PR TITLE
Addendum for #38343, can't launch screening room

### DIFF
--- a/python/tk_multi_screeningroom/screeningroom.py
+++ b/python/tk_multi_screeningroom/screeningroom.py
@@ -62,7 +62,7 @@ def _launch_rv(base_url, cmd, source=None, path_to_rv=None):
         webbrowser.open(url)
         return
 
-    cmdLine = " ".join([path_to_rv] + args)
+    cmdLine = " ".join(['"%s"' % path_to_rv] + args)
     print("Running %s" % cmdLine)
     subprocess.Popen(cmdLine, shell=True)
 

--- a/python/tk_multi_screeningroom/screeningroom.py
+++ b/python/tk_multi_screeningroom/screeningroom.py
@@ -64,7 +64,7 @@ def _launch_rv(base_url, cmd, source=None, path_to_rv=None):
 
     cmdLine = " ".join([path_to_rv] + args)
     print("Running %s" % cmdLine)
-    subprocess.Popen(cmdLine, shell=True))
+    subprocess.Popen(cmdLine, shell=True)
 
 def _serialize_mu_args(args):
     # Convert the list of key-value pairs to the equivalent Mu representation


### PR DESCRIPTION
Somehow I added an extra ) after testing my original fix. Also, this quotes the path to RV since Windows paths often have spaces in them (anything in C:\Program Files).