### PR TITLE
fix for commands not running from web interface context menu

### DIFF
--- a/app.py
+++ b/app.py
@@ -20,18 +20,34 @@ from tank.platform import Application
 from tank import TankError
 
 class MultiLaunchScreeningRoom(Application):
-    
+
     def init_app(self):
-        
-        if self.get_setting("enable_rv_mode"):        
-            self.engine.register_command("Jump to Screening Room in RV", 
+
+        if self.get_setting("enable_rv_mode"):
+
+            parameters = {
+                "short_name": "screening_room_rv",
+                "title": "Jump to Screening Room in RV",
+                "type": "context_menu",
+                "description": "Jump to Screening Room in RV"
+            }
+
+            self.engine.register_command(parameters['short_name'],
                                          self._start_screeningroom_rv,
-                                         {"type": "context_menu", "short_name": "screening_room_rv"})
-        
-        if self.get_setting("enable_web_mode"):        
-            self.engine.register_command("Jump to Screening Room Web Player", 
+                                         parameters)
+
+        if self.get_setting("enable_web_mode"):
+
+            parameters = {
+                "short_name": "screening_room_web",
+                "title": "Jump to Screening Room Web Player",
+                "type": "context_menu",
+                "description": "Jump to Screening Room Web Player"
+            }
+
+            self.engine.register_command(parameters['short_name'],
                                          self._start_screeningroom_web,
-                                         {"type": "context_menu", "short_name": "screening_room_web"})
+                                         parameters)
 
     @property
     def context_change_allowed(self):


### PR DESCRIPTION
This is a fix for error when launching screening room from web context menu

```
ERROR: A general error was reported: invalid literal for int() with base 10: 'Screening'
Traceback (most recent call last):
File "/sgconf/SDG_dev/install/core/scripts/tank_cmd.py", line 1542, in 
cmd_line[1:])
File "/sgconf/SDG_dev/install/core/scripts/tank_cmd.py", line 501, in shotgun_run_action_auth
entity_ids = [int(x) for x in entity_ids_str]
ValueError: invalid literal for int() with base 10: 'Screening'
```

