### PR TITLE
SG-20648 Adds multi selection support for Versions

### DIFF
--- a/app.py
+++ b/app.py
@@ -25,19 +25,26 @@ class MultiLaunchScreeningRoom(Application):
     def init_app(self):
 
         if self.get_setting("enable_rv_mode"):
+            command_settings = {
+                "type": "context_menu",
+                "short_name": "screening_room_rv",
+            }
             # We only support multiple selection for `Version`
             # entities when run in the `tk-shotgun` engine.
-            supports_multiple_selection = (
-                True if self.context.entity["type"] == "Version" else False
-            )
+            # The supports_multiple_selection setting holds two purposes
+            # Setting it to True will mean the engine allows the action
+            # to be run on multiple entities simultaneously from the browser.
+            # But even just defining the setting as false is enough
+            # for the engine to run the action command in a different way.
+            # Some engines don't support this old method, so we are only setting
+            # it if we want it to be True.
+            if self.context.entity["type"] == "Version":
+                command_settings["supports_multiple_selection"] = True
+
             self.engine.register_command(
                 "Jump to Screening Room in RV",
                 self._start_screeningroom_rv,
-                {
-                    "type": "context_menu",
-                    "short_name": "screening_room_rv",
-                    "supports_multiple_selection": supports_multiple_selection,
-                },
+                command_settings,
             )
 
         if self.get_setting("enable_web_mode"):

--- a/app.py
+++ b/app.py
@@ -38,7 +38,7 @@ class MultiLaunchScreeningRoom(Application):
             # for the engine to run the action command in a different way.
             # Some engines don't support this old method, so we are only setting
             # it if we want it to be True.
-            if self.context.entity["type"] == "Version":
+            if self.context.entity and self.context.entity["type"] == "Version":
                 command_settings["supports_multiple_selection"] = True
 
             self.engine.register_command(

--- a/app.py
+++ b/app.py
@@ -177,10 +177,10 @@ class MultiLaunchScreeningRoom(Application):
         """
 
         if entity_type == "Version" and entity_ids:
-            # if we have an entity_typ and entity_ids we are running in
+            # if we have an entity_type and entity_ids we are running in
             # the tk-shotgun engine on a Version entity.
             # RV can handle opening multiple versions so we pass through
-            # a Version ID list instead of the usual single entity
+            # a Version ID list instead of the usual single entity.
             entity = {"version_ids": entity_ids}
         else:
             entity = self._get_entity()

--- a/python/tk_multi_screeningroom/screeningroom.py
+++ b/python/tk_multi_screeningroom/screeningroom.py
@@ -174,8 +174,8 @@ def launch_timeline(base_url, context, path_to_rv=None):
                 ]
             )
         elif "version_ids" in context and len(context["version_ids"]) > 0:
-            # Provide a list of version IDs for RRV to select and add to the timeline in screeningroom
-            # We must select one version ID to be the main selected on.
+            # Provide a list of version IDs for RV to select and add to the timeline in screeningroom
+            # We must select one version ID to be the main selected one.
             args.append(("version_id", context["version_ids"][0]))
             args.append(
                 ("version_ids", ",".join(str(x) for x in context["version_ids"]))

--- a/python/tk_multi_screeningroom/screeningroom.py
+++ b/python/tk_multi_screeningroom/screeningroom.py
@@ -123,6 +123,9 @@ def launch_timeline(base_url, context, path_to_rv=None):
                             'Environment', 'Prop', etc.
             * `project_id`: A Shotgun project id.
 
+        * A list of Version ids
+            * `version_ids`: a list containing Version ids.
+
     :type context: `dict`
     :param path_to_rv: Optional. Path to the RV executable. If omitted, RV will be started
        via a web browser using the rvlink protocol
@@ -170,11 +173,18 @@ def launch_timeline(base_url, context, path_to_rv=None):
                     ("project_id", context["project_id"]),
                 ]
             )
+        elif "version_ids" in context and len(context["version_ids"]) > 0:
+            # Provide a list of version IDs for RRV to select and add to the timeline in screeningroom
+            # We must select one version ID to be the main selected on.
+            args.append(("version_id", context["version_ids"][0]))
+            args.append(
+                ("version_ids", ",".join(str(x) for x in context["version_ids"]))
+            )
         else:
             raise ScreeningRoomError(
                 "Invalid context supplied for the Screening Room timeline. Context "
-                'must contain either entity "type" and "id" entries, or '
-                '"asset_type" and "project_id" entries.'
+                'must contain either entity "type" and "id" entries, '
+                '"asset_type" and "project_id" entries, or a "version_ids" entry.'
             )
 
     # Convert the args to a Mu string representation


### PR DESCRIPTION
The user can now select Multiple versions in Shotgun and launch RV with them. Once in RV the selected Versions will be added to the timeline. However the view at present is not switched to a layout view, so only the first selected Version will be displayed in the viewer. 
<img width="493" alt="Screenshot 2021-01-27 at 10 13 46" src="https://user-images.githubusercontent.com/3777228/105976535-31aa5f80-6088-11eb-9ec0-398b9f009794.png">

<img width="705" alt="Screenshot 2021-01-27 at 10 16 43" src="https://user-images.githubusercontent.com/3777228/105976940-b1382e80-6088-11eb-872c-d214d5441362.png">
