### PR TITLE
SG-43664 Drop Python 3.7 support

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,7 +33,7 @@ repos:
     - id: trailing-whitespace
   # Leave black at the bottom so all touchups are done before it is run.
   - repo: https://github.com/psf/black
-    rev: 26.1.0
+    rev: 26.5.1
     hooks:
     - id: black
       language_version: python3

--- a/info.yml
+++ b/info.yml
@@ -55,3 +55,4 @@ description: "Screening Room integration right inside your application."
 requires_shotgun_version:
 requires_core_version: "v0.19.1"
 requires_engine_version:
+minimum_python_version: "3.9"


### PR DESCRIPTION
## Summary
- Set `minimum_python_version: "3.9"` in `info.yml`

## Test plan
- [ ] Pre-commit passes (black, check-ast, check-yaml, whitespace)

🤖 Generated with [Claude Code](https://claude.com/claude-code)